### PR TITLE
Add Python WhatsApp bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# ACMDA
+
+All-in-one AI Customer Messaging & Developer Assistant (ACMDA).
+
+This PHP project provides:
+- SQLite-backed memory storage for conversational context.
+- Rule-based drafting of replies for customer messages.
+- A WhatsApp message pipeline with pending/approved/sent states.
+- Persistent business context (services offered, excluded, policy) stored in SQLite.
+
+## Usage
+
+```
+php acmda.php [command]
+```
+
+Commands:
+- `receive <sender> <message>`: store a customer message and draft a reply.
+- `approve <id>`: mark a drafted message as approved.
+- `reject <id>`: mark a drafted message as rejected.
+- `send`: output and mark all approved messages as sent.
+- `memory <user>`: show stored conversation history for a user.
+
+### WhatsApp integration
+
+- `wa_webhook.php`: endpoint for Meta to deliver inbound messages. Supports verify-token check and stores messages as pending.
+- `wa_send.php`: CLI script for cron jobs to send all approved messages.
+
+### Python bridge
+
+- `acmda_bridge.py`: example script showing how to forward webhook messages to the local ACMDA service and post replies back.
+- `requirements.txt`: required Python packages for the bridge and optional Telegram support.
+
+## Testing
+
+Install dependencies and run the tests:
+
+```
+composer install
+./vendor/bin/phpunit
+```

--- a/acmda.php
+++ b/acmda.php
@@ -2,6 +2,8 @@
 // All-in-one AI Customer Messaging & Developer Assistant (ACMDA)
 // This single script provides memory, RAG, and a WhatsApp message pipeline.
 
+require_once __DIR__ . '/mem.php';
+
 $dbFile = __DIR__ . '/acmda.sqlite';
 
 function initDb(string $dbFile): PDO {
@@ -26,6 +28,7 @@ function initDb(string $dbFile): PDO {
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         );
     SQL);
+    initBusiness($db);
     return $db;
 }
 
@@ -40,13 +43,17 @@ function getMemory(PDO $db, string $user): array {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$services = [
-    'offers' => ['assembly', 'doors', 'locks', 'tiling', 'plumbing repairs'],
-    'not_offered' => ['carpet fitting', 'electrical rewiring'],
-    'policy' => 'Please use the online booking system for prices and availability.'
-];
 
-function draftReply(PDO $db, string $user, string $message, array $services): string {
+function defaultServices(): array {
+    return [
+        'offers' => ['assembly', 'doors', 'locks', 'tiling', 'plumbing repairs'],
+        'not_offered' => ['carpet fitting', 'electrical rewiring'],
+        'policy' => 'Please use the online booking system for prices and availability.'
+    ];
+}
+
+function draftReply(PDO $db, string $user, string $message): string {
+    $services = loadBusinessData($db);
     $lower = strtolower($message);
     foreach ($services['offers'] as $service) {
         if (str_contains($lower, $service)) {
@@ -67,8 +74,8 @@ function draftReply(PDO $db, string $user, string $message, array $services): st
     return $reply;
 }
 
-function receiveMessage(PDO $db, string $sender, string $message, array $services): int {
-    $draft = draftReply($db, $sender, $message, $services);
+function receiveMessage(PDO $db, string $sender, string $message): int {
+    $draft = draftReply($db, $sender, $message);
     $stmt = $db->prepare('INSERT INTO wa_messages(sender, message, draft, status) VALUES (?, ?, ?, "pending")');
     $stmt->execute([$sender, $message, $draft]);
     return (int) $db->lastInsertId();
@@ -96,13 +103,19 @@ function sendApprovedMessages(PDO $db): void {
 
 if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $db = initDb($dbFile);
+    $services = loadBusinessData($db);
+    if (!$services) {
+        $services = defaultServices();
+        saveBusinessData($db, $services);
+    }
+
     $cmd = $argv[1] ?? '';
 
     switch ($cmd) {
         case 'receive':
             $sender = $argv[2] ?? 'customer';
             $msg = $argv[3] ?? '';
-            $id = receiveMessage($db, $sender, $msg, $services);
+            $id = receiveMessage($db, $sender, $msg);
             echo "Message stored with id $id\n";
             break;
         case 'approve':

--- a/acmda_bridge.py
+++ b/acmda_bridge.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Bridge WhatsApp webhook with ACMDA and host environment.
+
+This script demonstrates how to connect incoming WhatsApp messages
+received via Hostinger to the local ACMDA service. It also shows how to
+send approved responses back through the same webhook.
+
+Requirements:
+  - requests
+  - pywhat3k (WhatsApp integration helper)
+  - python-telegram-bot (optional Telegram support)
+
+Configuration is done via environment variables:
+  ACMDA_API_URL   -> endpoint for local ACMDA (default http://localhost/acmda.php)
+  ACMDA_API_KEY   -> key for authenticating with ACMDA
+  HOSTINGER_WH_URL-> webhook URL on Hostinger to post outbound messages
+"""
+
+import json
+import os
+from typing import Dict
+
+import requests
+
+try:
+    import pywhat3k  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - library optional for this demo
+    pass
+
+ACMDA_API_URL = os.getenv("ACMDA_API_URL", "http://localhost/acmda.php")
+ACMDA_API_KEY = os.getenv("ACMDA_API_KEY", "test-key")
+HOSTINGER_WH_URL = os.getenv("HOSTINGER_WH_URL", "http://localhost/webhook")
+
+
+def handle_incoming(payload: Dict[str, str]) -> Dict[str, str]:
+    """Forward inbound WhatsApp message to ACMDA and return its draft reply."""
+    sender = payload.get("from", "")
+    text = payload.get("text", "")
+    data = {"sender": sender, "message": text}
+    headers = {"Authorization": f"Bearer {ACMDA_API_KEY}"}
+    resp = requests.post(ACMDA_API_URL, json=data, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def send_response(to: str, text: str) -> None:
+    """Send an approved message back to Hostinger for dispatch."""
+    data = {"to": to, "text": text}
+    resp = requests.post(HOSTINGER_WH_URL, json=data, timeout=10)
+    resp.raise_for_status()
+
+
+def demo() -> None:
+    """Run a small demo using hard-coded values."""
+    sample = {"from": "+441234567890", "text": "Can you fit a lock?"}
+    ai = handle_incoming(sample)
+    reply = ai.get("reply", "")
+    send_response(sample["from"], reply)
+    print("Processed sample message")
+
+
+if __name__ == "__main__":
+    if os.environ.get("ACMDA_BRIDGE_DEMO"):
+        demo()

--- a/mem.php
+++ b/mem.php
@@ -1,0 +1,27 @@
+<?php
+// Memory layer for business context and conversation history.
+
+function initBusiness(PDO $db): void {
+    $db->exec(
+        'CREATE TABLE IF NOT EXISTS business (key TEXT PRIMARY KEY, value TEXT)'
+    );
+}
+
+function saveBusinessData(PDO $db, array $data): void {
+    $stmt = $db->prepare('REPLACE INTO business(key, value) VALUES(:key, :value)');
+    foreach ($data as $key => $value) {
+        $stmt->execute([
+            ':key' => $key,
+            ':value' => json_encode($value)
+        ]);
+    }
+}
+
+function loadBusinessData(PDO $db): array {
+    $stmt = $db->query('SELECT key, value FROM business');
+    $out = [];
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $out[$row['key']] = json_decode($row['value'], true);
+    }
+    return $out;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pywhat3k
+python-telegram-bot

--- a/services.txt
+++ b/services.txt
@@ -1,0 +1,20 @@
+Handyman Plus Van Services
+=========================
+
+Provided:
+- Furniture assembly
+- Door and lock fitting
+- Shelving and small carpentry
+- Tiling repairs
+- Minor plumbing repairs (leaks, tap replacement)
+- Painting and decorating
+
+Not Offered:
+- Gas work or boiler servicing
+- Major electrical installations or rewiring
+- Carpet fitting
+- Large structural renovations
+
+Pricing & Booking:
+Quotes and availability are handled via the booking system on https://www.handymanplusvan.co.uk.
+Please do not book directly through messages.

--- a/wa_send.php
+++ b/wa_send.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/acmda.php';
+
+if (php_sapi_name() !== 'cli') {
+    http_response_code(400);
+    echo "CLI only";
+    exit;
+}
+
+$db = initDb(__DIR__ . '/acmda.sqlite');
+sendApprovedMessages($db);

--- a/wa_webhook.php
+++ b/wa_webhook.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/acmda.php';
+
+function waHandleWebhook(PDO $db, string $method, array $query, string $payload, string $verifyToken): array {
+    if ($method === 'GET') {
+        $token = $query['hub_verify_token'] ?? '';
+        $challenge = $query['hub_challenge'] ?? '';
+        if ($token === $verifyToken) {
+            return [200, $challenge];
+        }
+        return [403, 'Invalid verify token'];
+    }
+
+    if ($method === 'POST') {
+        $data = json_decode($payload, true);
+        $msg = $data['entry'][0]['changes'][0]['value']['messages'][0] ?? null;
+        if ($msg) {
+            $from = $msg['from'] ?? '';
+            $text = $msg['text']['body'] ?? '';
+            receiveMessage($db, $from, $text);
+        }
+        return [200, 'OK'];
+    }
+
+    return [405, 'Method not allowed'];
+}
+
+if (php_sapi_name() !== 'cli') {
+    $db = initDb(__DIR__ . '/acmda.sqlite');
+    $verify = getenv('WA_VERIFY_TOKEN') ?: 'test-token';
+    [$code, $body] = waHandleWebhook($db, $_SERVER['REQUEST_METHOD'], $_GET, file_get_contents('php://input'), $verify);
+    http_response_code($code);
+    echo $body;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handyman Plus Van</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    header { text-align: center; }
+    nav a { margin: 0 1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Reliable, Local and Affordable Handyman Services in Swindon</h1>
+    <nav>
+      <a href="services.html">Services</a>
+      <a href="mailto:ian@handymanplusvan.co.uk">Email</a>
+    </nav>
+  </header>
+  <main>
+    <p>Handyman Plus Van provides professional home repairs and improvements across Swindon and the surrounding area.</p>
+    <p>For quotes and booking information please visit <a href="https://www.handymanplusvan.co.uk">handymanplusvan.co.uk</a>.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Handyman Plus Van</p>
+  </footer>
+</body>
+</html>

--- a/website/services.html
+++ b/website/services.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Services - Handyman Plus Van</title>
+</head>
+<body>
+  <h1>Services</h1>
+  <ul>
+    <li>Furniture assembly</li>
+    <li>Door hanging and lock fitting</li>
+    <li>Shelving and small carpentry</li>
+    <li>Tiling repairs</li>
+    <li>Minor plumbing repairs (leaks, tap replacement)</li>
+    <li>Painting and decorating</li>
+  </ul>
+  <p>We do not undertake gas work, major electrical jobs, carpet fitting or large-scale renovations.</p>
+  <p>For quotes and availability visit <a href="https://www.handymanplusvan.co.uk">handymanplusvan.co.uk</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document and ship `acmda_bridge.py` Python helper for forwarding WhatsApp webhooks to ACMDA and returning replies
- list Python dependencies in new `requirements.txt`
- update README to mention the bridge and its packages

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c53eca1e248322b4653117b647d0e2