### PR TITLE
Add approval dashboard and robust WhatsApp bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# ACMDA
+
+All-in-one AI Customer Messaging & Developer Assistant (ACMDA).
+
+This PHP project provides:
+- SQLite-backed memory storage for conversational context.
+- Rule-based drafting of replies for customer messages.
+- A WhatsApp message pipeline with pending/approved/sent states.
+- Persistent business context (services offered, excluded, policy) stored in SQLite.
+
+## Usage
+
+```
+php acmda.php [command]
+```
+
+Commands:
+- `receive <sender> <message>`: store a customer message and draft a reply.
+- `approve <id>`: mark a drafted message as approved.
+- `reject <id>`: mark a drafted message as rejected.
+- `send`: output and mark all approved messages as sent.
+- `memory <user>`: show stored conversation history for a user.
+
+### WhatsApp integration
+
+- `wa_webhook.php`: endpoint for Meta to deliver inbound messages. Supports verify-token check and stores messages as pending.
+- `wa_send.php`: CLI script for cron jobs to send all approved messages.
+- `wa_approve.php`: simple dashboard to review pending drafts and approve or reject them.
+
+### Python bridge
+
+- `acmda_bridge.py`: polls the Hostinger webhook, forwards messages to ACMDA and posts replies back, with optional Telegram notifications and a continuous loop mode.
+- `requirements.txt`: required Python packages for the bridge and optional Telegram support.
+
+## Testing
+
+Install dependencies and run the tests:
+
+```
+composer install
+./vendor/bin/phpunit
+```

--- a/acmda.php
+++ b/acmda.php
@@ -2,6 +2,8 @@
 // All-in-one AI Customer Messaging & Developer Assistant (ACMDA)
 // This single script provides memory, RAG, and a WhatsApp message pipeline.
 
+require_once __DIR__ . '/mem.php';
+
 $dbFile = __DIR__ . '/acmda.sqlite';
 
 function initDb(string $dbFile): PDO {
@@ -26,6 +28,7 @@ function initDb(string $dbFile): PDO {
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         );
     SQL);
+    initBusiness($db);
     return $db;
 }
 
@@ -40,13 +43,17 @@ function getMemory(PDO $db, string $user): array {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$services = [
-    'offers' => ['assembly', 'doors', 'locks', 'tiling', 'plumbing repairs'],
-    'not_offered' => ['carpet fitting', 'electrical rewiring'],
-    'policy' => 'Please use the online booking system for prices and availability.'
-];
 
-function draftReply(PDO $db, string $user, string $message, array $services): string {
+function defaultServices(): array {
+    return [
+        'offers' => ['assembly', 'doors', 'locks', 'tiling', 'plumbing repairs'],
+        'not_offered' => ['carpet fitting', 'electrical rewiring'],
+        'policy' => 'Please use the online booking system for prices and availability.'
+    ];
+}
+
+function draftReply(PDO $db, string $user, string $message): string {
+    $services = loadBusinessData($db);
     $lower = strtolower($message);
     foreach ($services['offers'] as $service) {
         if (str_contains($lower, $service)) {
@@ -67,8 +74,8 @@ function draftReply(PDO $db, string $user, string $message, array $services): st
     return $reply;
 }
 
-function receiveMessage(PDO $db, string $sender, string $message, array $services): int {
-    $draft = draftReply($db, $sender, $message, $services);
+function receiveMessage(PDO $db, string $sender, string $message): int {
+    $draft = draftReply($db, $sender, $message);
     $stmt = $db->prepare('INSERT INTO wa_messages(sender, message, draft, status) VALUES (?, ?, ?, "pending")');
     $stmt->execute([$sender, $message, $draft]);
     return (int) $db->lastInsertId();
@@ -96,13 +103,19 @@ function sendApprovedMessages(PDO $db): void {
 
 if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     $db = initDb($dbFile);
+    $services = loadBusinessData($db);
+    if (!$services) {
+        $services = defaultServices();
+        saveBusinessData($db, $services);
+    }
+
     $cmd = $argv[1] ?? '';
 
     switch ($cmd) {
         case 'receive':
             $sender = $argv[2] ?? 'customer';
             $msg = $argv[3] ?? '';
-            $id = receiveMessage($db, $sender, $msg, $services);
+            $id = receiveMessage($db, $sender, $msg);
             echo "Message stored with id $id\n";
             break;
         case 'approve':

--- a/acmda_bridge.py
+++ b/acmda_bridge.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Bridge WhatsApp webhook with ACMDA and host environment.
+
+This helper polls a Hostinger webhook for inbound WhatsApp messages,
+forwards them to the local ACMDA service, and can notify Telegram when
+approved replies are dispatched. It keeps all processing local while
+demonstrating how ACMDA integrates with external platforms.
+
+Configuration is done via environment variables:
+  ACMDA_API_URL    -> endpoint for local ACMDA (default http://localhost/acmda.php)
+  ACMDA_API_KEY    -> key for authenticating with ACMDA
+  HOSTINGER_WH_URL -> webhook URL on Hostinger to poll/send messages
+  TELEGRAM_TOKEN   -> bot token for notifications (optional)
+  TELEGRAM_CHAT_ID -> chat ID to receive notifications (optional)
+  ACMDA_BRIDGE_LOOP -> set to any value to enable polling loop
+  ACMDA_BRIDGE_DEMO -> set to run a single demo message
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Dict, List
+
+import requests
+from requests import RequestException
+
+try:  # pragma: no cover - optional dependency
+    import pywhat3k  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover
+    pass
+
+try:  # pragma: no cover - optional dependency
+    from telegram import Bot  # type: ignore
+except Exception:  # pragma: no cover
+    Bot = None  # type: ignore
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+ACMDA_API_URL = os.getenv("ACMDA_API_URL", "http://localhost/acmda.php")
+ACMDA_API_KEY = os.getenv("ACMDA_API_KEY", "test-key")
+HOSTINGER_WH_URL = os.getenv("HOSTINGER_WH_URL", "http://localhost/webhook")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+
+
+def fetch_messages() -> List[Dict[str, str]]:
+    """Poll Hostinger webhook for new messages."""
+    try:
+        resp = requests.get(HOSTINGER_WH_URL, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list):
+            return data
+        log.warning("Unexpected webhook payload: %s", data)
+    except RequestException as exc:
+        log.error("Fetching messages failed: %s", exc)
+    except ValueError as exc:
+        log.error("Invalid JSON from webhook: %s", exc)
+    return []
+
+
+def handle_incoming(payload: Dict[str, str]) -> Dict[str, str]:
+    """Forward inbound message to ACMDA and return its draft reply."""
+    sender = payload.get("from", "")
+    text = payload.get("text", "")
+    data = {"sender": sender, "message": text}
+    headers = {"Authorization": f"Bearer {ACMDA_API_KEY}"}
+    try:
+        resp = requests.post(ACMDA_API_URL, json=data, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except RequestException as exc:
+        log.error("ACMDA request failed: %s", exc)
+        return {"error": str(exc)}
+
+
+def send_response(to: str, text: str) -> None:
+    """Send an approved message back to Hostinger and Telegram."""
+    data = {"to": to, "text": text}
+    try:
+        resp = requests.post(HOSTINGER_WH_URL, json=data, timeout=10)
+        resp.raise_for_status()
+    except RequestException as exc:
+        log.error("Sending response failed: %s", exc)
+    if TELEGRAM_TOKEN and TELEGRAM_CHAT_ID and Bot:
+        try:
+            bot = Bot(token=TELEGRAM_TOKEN)
+            bot.send_message(chat_id=TELEGRAM_CHAT_ID, text=f"Sent to {to}: {text}")
+        except Exception as exc:  # pragma: no cover - network side effect
+            log.error("Telegram notification failed: %s", exc)
+
+
+def run_loop(interval: int = 5) -> None:
+    """Continuously poll for messages and process them."""
+    log.info("Starting poll loop with %ss interval", interval)
+    while True:
+        for msg in fetch_messages():
+            ai = handle_incoming(msg)
+            reply = ai.get("reply")
+            if reply:
+                send_response(msg.get("from", ""), reply)
+        time.sleep(interval)
+
+
+def demo() -> None:
+    """Run a small demo using hard-coded values."""
+    sample = {"from": "+441234567890", "text": "Can you fit a lock?"}
+    ai = handle_incoming(sample)
+    reply = ai.get("reply", "")
+    send_response(sample["from"], reply)
+    print("Processed sample message")
+
+
+if __name__ == "__main__":
+    if os.getenv("ACMDA_BRIDGE_LOOP"):
+        run_loop()
+    elif os.getenv("ACMDA_BRIDGE_DEMO"):
+        demo()

--- a/mem.php
+++ b/mem.php
@@ -1,0 +1,27 @@
+<?php
+// Memory layer for business context and conversation history.
+
+function initBusiness(PDO $db): void {
+    $db->exec(
+        'CREATE TABLE IF NOT EXISTS business (key TEXT PRIMARY KEY, value TEXT)'
+    );
+}
+
+function saveBusinessData(PDO $db, array $data): void {
+    $stmt = $db->prepare('REPLACE INTO business(key, value) VALUES(:key, :value)');
+    foreach ($data as $key => $value) {
+        $stmt->execute([
+            ':key' => $key,
+            ':value' => json_encode($value)
+        ]);
+    }
+}
+
+function loadBusinessData(PDO $db): array {
+    $stmt = $db->query('SELECT key, value FROM business');
+    $out = [];
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $out[$row['key']] = json_decode($row['value'], true);
+    }
+    return $out;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pywhat3k
+python-telegram-bot

--- a/services.txt
+++ b/services.txt
@@ -1,0 +1,20 @@
+Handyman Plus Van Services
+=========================
+
+Provided:
+- Furniture assembly
+- Door and lock fitting
+- Shelving and small carpentry
+- Tiling repairs
+- Minor plumbing repairs (leaks, tap replacement)
+- Painting and decorating
+
+Not Offered:
+- Gas work or boiler servicing
+- Major electrical installations or rewiring
+- Carpet fitting
+- Large structural renovations
+
+Pricing & Booking:
+Quotes and availability are handled via the booking system on https://www.handymanplusvan.co.uk.
+Please do not book directly through messages.

--- a/wa_approve.php
+++ b/wa_approve.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/acmda.php';
+
+$db = initDb(__DIR__ . '/acmda.sqlite');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = (int) ($_POST['id'] ?? 0);
+    if (isset($_POST['approve'])) {
+        approveMessage($db, $id);
+    } elseif (isset($_POST['reject'])) {
+        rejectMessage($db, $id);
+    }
+    header('Location: wa_approve.php');
+    exit;
+}
+
+$msgs = $db->query('SELECT id, sender, message, draft FROM wa_messages WHERE status = "pending"')
+    ->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Pending WhatsApp Messages</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        .msg { border: 1px solid #ccc; padding: 1em; margin-bottom: 1em; }
+        .msg p { margin: .3em 0; }
+    </style>
+</head>
+<body>
+<h1>Pending WhatsApp Messages</h1>
+<?php foreach ($msgs as $m): ?>
+    <div class="msg">
+        <p><strong>From:</strong> <?= htmlspecialchars($m['sender']) ?></p>
+        <p><strong>Message:</strong> <?= htmlspecialchars($m['message']) ?></p>
+        <p><strong>Draft:</strong> <?= htmlspecialchars($m['draft']) ?></p>
+        <form method="post">
+            <input type="hidden" name="id" value="<?= $m['id'] ?>">
+            <button name="approve">Approve</button>
+            <button name="reject">Reject</button>
+        </form>
+    </div>
+<?php endforeach; ?>
+</body>
+</html>

--- a/wa_send.php
+++ b/wa_send.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/acmda.php';
+
+if (php_sapi_name() !== 'cli') {
+    http_response_code(400);
+    echo "CLI only";
+    exit;
+}
+
+$db = initDb(__DIR__ . '/acmda.sqlite');
+sendApprovedMessages($db);

--- a/wa_webhook.php
+++ b/wa_webhook.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/acmda.php';
+
+function waHandleWebhook(PDO $db, string $method, array $query, string $payload, string $verifyToken): array {
+    if ($method === 'GET') {
+        $token = $query['hub_verify_token'] ?? '';
+        $challenge = $query['hub_challenge'] ?? '';
+        if ($token === $verifyToken) {
+            return [200, $challenge];
+        }
+        return [403, 'Invalid verify token'];
+    }
+
+    if ($method === 'POST') {
+        $data = json_decode($payload, true);
+        $msg = $data['entry'][0]['changes'][0]['value']['messages'][0] ?? null;
+        if ($msg) {
+            $from = $msg['from'] ?? '';
+            $text = $msg['text']['body'] ?? '';
+            receiveMessage($db, $from, $text);
+        }
+        return [200, 'OK'];
+    }
+
+    return [405, 'Method not allowed'];
+}
+
+if (php_sapi_name() !== 'cli') {
+    $db = initDb(__DIR__ . '/acmda.sqlite');
+    $verify = getenv('WA_VERIFY_TOKEN') ?: 'test-token';
+    [$code, $body] = waHandleWebhook($db, $_SERVER['REQUEST_METHOD'], $_GET, file_get_contents('php://input'), $verify);
+    http_response_code($code);
+    echo $body;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handyman Plus Van</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    header { text-align: center; }
+    nav a { margin: 0 1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Reliable, Local and Affordable Handyman Services in Swindon</h1>
+    <nav>
+      <a href="services.html">Services</a>
+      <a href="mailto:ian@handymanplusvan.co.uk">Email</a>
+    </nav>
+  </header>
+  <main>
+    <p>Handyman Plus Van provides professional home repairs and improvements across Swindon and the surrounding area.</p>
+    <p>For quotes and booking information please visit <a href="https://www.handymanplusvan.co.uk">handymanplusvan.co.uk</a>.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Handyman Plus Van</p>
+  </footer>
+</body>
+</html>

--- a/website/services.html
+++ b/website/services.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Services - Handyman Plus Van</title>
+</head>
+<body>
+  <h1>Services</h1>
+  <ul>
+    <li>Furniture assembly</li>
+    <li>Door hanging and lock fitting</li>
+    <li>Shelving and small carpentry</li>
+    <li>Tiling repairs</li>
+    <li>Minor plumbing repairs (leaks, tap replacement)</li>
+    <li>Painting and decorating</li>
+  </ul>
+  <p>We do not undertake gas work, major electrical jobs, carpet fitting or large-scale renovations.</p>
+  <p>For quotes and availability visit <a href="https://www.handymanplusvan.co.uk">handymanplusvan.co.uk</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enhance `acmda_bridge.py` with polling loop, error logging, and optional Telegram notifications
- add `wa_approve.php` web page to review, approve, or reject pending WhatsApp drafts
- document the approval dashboard and bridge features in the README

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c53eca1e248322b4653117b647d0e2